### PR TITLE
DM-7987: Ambiguous conversion between spherical coordinates and unit vectors 

### DIFF
--- a/include/lsst/sphgeom/LonLat.h
+++ b/include/lsst/sphgeom/LonLat.h
@@ -38,6 +38,13 @@ namespace sphgeom {
 class Vector3d;
 
 /// `LonLat` represents a spherical coordinate (longitude/latitude angle) pair.
+///
+/// This class supports conversion from a `Vector3d`. All methods that accept a
+/// `Vector3d` parameter shall convert from vector to longitude/latitude
+/// coordinates according to the following conventions:
+/// * (1, 0, 0) → (0°, 0°)
+/// * (0, 1, 0) → (90°, 0°)
+/// * (0, 0, 1) → (0°, +90°)
 class LonLat {
 public:
     static LonLat fromDegrees(double lon, double lat) {

--- a/include/lsst/sphgeom/UnitVector3d.h
+++ b/include/lsst/sphgeom/UnitVector3d.h
@@ -45,6 +45,13 @@ namespace sphgeom {
 /// components yielding non-unit norm. For a class this compact and performance
 /// critical, the addition of a vtable pointer per instance and the potential
 /// for virtual call overhead on assignment is deemed prohibitive.
+///
+/// This class supports conversion from longitude and latitude angles. All
+/// methods that accept a `LonLat` or equivalent angles shall convert from
+/// longitude/latitude to a unit vector according to the following conventions:
+/// * (0°, 0°) → (1, 0, 0)
+/// * (90°, 0°) → (0, 1, 0)
+/// * (0°, +90°) → (0, 0, 1)
 class UnitVector3d {
 public:
     /// `orthogonalTo` returns an arbitrary unit vector that is


### PR DESCRIPTION
This patch makes explicit `sphgeom`'s conventions for converting between vector and angular representations of a point on a sphere. It only formalizes existing behavior, so no client code should break. The conventions are documented at the class level rather than the method level, as each class has multiple conversion methods.