### PR TITLE
DM-11585: Add pytest support to packages

### DIFF
--- a/tests/test_Angle.py
+++ b/tests/test_Angle.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_AngleIntervals.py
+++ b/tests/test_AngleIntervals.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_Box.py
+++ b/tests/test_Box.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_Box3d.py
+++ b/tests/test_Box3d.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_Chunker.py
+++ b/tests/test_Chunker.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_Circle.py
+++ b/tests/test_Circle.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_ConvexPolygon.py
+++ b/tests/test_ConvexPolygon.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_Ellipse.py
+++ b/tests/test_Ellipse.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_HtmPixelization.py
+++ b/tests/test_HtmPixelization.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_Interval1d.py
+++ b/tests/test_Interval1d.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_LonLat.py
+++ b/tests/test_LonLat.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_Matrix3d.py
+++ b/tests/test_Matrix3d.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_Mq3cPixelization.py
+++ b/tests/test_Mq3cPixelization.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_NormalizedAngle.py
+++ b/tests/test_NormalizedAngle.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_Q3cPixelization.py
+++ b/tests/test_Q3cPixelization.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_RangeSet.py
+++ b/tests/test_RangeSet.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_UnitVector3d.py
+++ b/tests/test_UnitVector3d.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.

--- a/tests/test_Vector3d.py
+++ b/tests/test_Vector3d.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # LSST Data Management System
 # See COPYRIGHT file at the top of the source tree.


### PR DESCRIPTION
Changes required for the [RFC-215/RFC-229 test file renaming](https://confluence.lsstcorp.org/pages/viewpage.action?pageId=58950873). See the top of that page for the exact changes required.