### PR TITLE
DM-27354: Enable pip installation using pyproject.toml / PEP 517

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,11 +15,10 @@ jobs:
         with:
           python-version: 3.7
 
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-
       - name: Build and install
-        run: pip install -v .
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install .[yaml,test]
 
       - name: Run tests
         run: pytest -r a -v

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ tests/.cache/*
 ups/*.cfgc
 build/
 .eggs/
+*.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include README.md
+recursive-include include *.h
+recursive-include src *.h

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [
+    "setuptools >= 46.6.0",
+    "wheel",
+    "pybind11 >= 2.5.0",
+    "numpy >= 1.18",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-pybind11 >=2.5.0
-setuptools >=46.0
-setuptools_cpp >=0.0.1
-pyyaml >=5.1
-pytest >= 3.2
-flake8 >= 3.7.5
-pytest-flake8 >= 1.0.4
-numpy >=1.18

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,12 +17,6 @@ zip_safe = False
 package_dir=
     =python
 packages=find:
-setup_requires =
-  setuptools >=46.0
-  wheel
-  pybind11 >=2.5.0
-  numpy >=1.18
-  setuptools_cpp >=0.0.1
 install_requires =
   numpy >=1.18
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,10 +21,10 @@ setup_requires =
   setuptools >=46.0
   wheel
   pybind11 >=2.5.0
-  numpy >=1.17
+  numpy >=1.18
   setuptools_cpp >=0.0.1
 install_requires =
-  numpy >=1.17
+  numpy >=1.18
 
 [options.extras_require]
 yaml = pyyaml>=5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,15 @@
 [metadata]
 name = lsst_sphgeom
-description = A Spherical Geometry Library
+description = A spherical geometry library.
 author = LSST Data Management
 author_email = support@lsst.org
-license = GPLv3
 url = https://github.com/lsst/sphgeom
 classifiers =
     Intended Audience :: Science/Research
     License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Topic :: Scientific/Engineering :: Astronomy
 
 [options]
@@ -35,7 +34,7 @@ tests_require =
 yaml = pyyaml>=5.1
 
 [options.packages.find]
-where=python
+where = python
 
 [flake8]
 max-line-length = 110

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,13 +25,13 @@ setup_requires =
   setuptools_cpp >=0.0.1
 install_requires =
   numpy >=1.17
-tests_require =
-  pytest >= 3.2
-  flake8 >= 3.7.5
-  pytest-flake8 >= 1.0.4
 
 [options.extras_require]
 yaml = pyyaml>=5.1
+test =
+  pytest >= 3.2
+  flake8 >= 3.7.5
+  pytest-flake8 >= 1.0.4
 
 [options.packages.find]
 where = python

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ This is not a complete definition.
   interface.
 """
 
-from setuptools import setup
-from setuptools_cpp import ExtensionBuilder, Pybind11Extension
 import glob
 
 # Importing this automatically enables parallelized builds
 import numpy.distutils.ccompiler  # noqa: F401
+from setuptools import setup
+from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 # Currently a fake version for testing
 version = '0.0.1'
@@ -40,5 +40,5 @@ ext_modules = [Pybind11Extension("lsst.sphgeom._sphgeom",
 setup(
     version=version,
     ext_modules=ext_modules,
-    cmdclass={'build_ext': ExtensionBuilder},
+    cmdclass={'build_ext': build_ext},
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ This is not a complete definition.
 
 from setuptools import setup
 from setuptools_cpp import ExtensionBuilder, Pybind11Extension
-import os
 import glob
 
 # Importing this automatically enables parallelized builds
@@ -28,11 +27,6 @@ __all__ = ("__version__", )
 __version__ = '{version}'""", file=f)
 
 
-# read the contents of the README file
-this_directory = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(this_directory, "README.md"), encoding='utf-8') as f:
-    long_description = f.read()
-
 # Find the source code -- we can combine it into a single module
 pybind_src = sorted(glob.glob("python/lsst/sphgeom/*.cc"))
 cpp_src = sorted(glob.glob("src/*.cc"))
@@ -45,8 +39,6 @@ ext_modules = [Pybind11Extension("lsst.sphgeom._sphgeom",
 
 setup(
     version=version,
-    long_description=long_description,
     ext_modules=ext_modules,
-    long_description_content_type="text/markdown",
     cmdclass={'build_ext': ExtensionBuilder},
 )


### PR DESCRIPTION
This PR makes sphgeom pip installable by downstream packages without requiring a requirements.txt file to pre-populate the environment. The solution here relies on the pyproject.toml file to ensure that build dependencies are installed before setuptools is called to build and install the package. This relies on the new-ish PEP 517 mechanism for specifying the build requirements.

This work also removes the extra `setuptools_cpp` dependency as it didn't seem to add any value compared to pybind11's built-in setuptools integration.