### PR TITLE
[DM-32256] Fix compilation with g++ 11

### DIFF
--- a/include/lsst/sphgeom/AngleInterval.h
+++ b/include/lsst/sphgeom/AngleInterval.h
@@ -27,6 +27,7 @@
 /// \brief This file defines a class for representing angle intervals.
 
 #include <iosfwd>
+#include <limits>
 
 #include "Angle.h"
 #include "Interval.h"

--- a/include/lsst/sphgeom/Ellipse.h
+++ b/include/lsst/sphgeom/Ellipse.h
@@ -28,6 +28,7 @@
 ///        regions on the unit sphere.
 
 #include <iosfwd>
+#include <limits>
 
 #include "Circle.h"
 #include "Matrix3d.h"

--- a/include/lsst/sphgeom/Interval1d.h
+++ b/include/lsst/sphgeom/Interval1d.h
@@ -27,6 +27,7 @@
 /// \brief This file defines a class for representing intervals of ℝ.
 
 #include <iosfwd>
+#include <limits>
 
 #include "Interval.h"
 

--- a/include/lsst/sphgeom/NormalizedAngle.h
+++ b/include/lsst/sphgeom/NormalizedAngle.h
@@ -26,6 +26,8 @@
 /// \file
 /// \brief This file declares a class for representing normalized angles.
 
+#include <limits>
+
 #include "Angle.h"
 
 

--- a/tests/testBox3d.cc
+++ b/tests/testBox3d.cc
@@ -23,6 +23,7 @@
 /// \file
 /// \brief This file contains tests for the Box class.
 
+#include <limits>
 #include <memory>
 
 #include "lsst/sphgeom/Box3d.h"

--- a/tests/testCircle.cc
+++ b/tests/testCircle.cc
@@ -23,6 +23,7 @@
 /// \file
 /// \brief This file contains tests for the Box class.
 
+#include <limits>
 #include <memory>
 #include <vector>
 

--- a/tests/testEllipse.cc
+++ b/tests/testEllipse.cc
@@ -23,6 +23,7 @@
 /// \file
 /// \brief This file contains tests for the Ellipse class.
 
+#include <limits>
 #include <memory>
 #include <vector>
 

--- a/tests/testNormalizedAngle.cc
+++ b/tests/testNormalizedAngle.cc
@@ -23,6 +23,7 @@
 /// \file
 /// \brief This file contains tests for the Angle class.
 
+#include <limits>
 #include <sstream>
 #include <string>
 

--- a/tests/testVector3d.cc
+++ b/tests/testVector3d.cc
@@ -22,6 +22,9 @@
 
 /// \file
 /// \brief This file contains tests for the Vector3d class.
+
+#include <limits>
+
 #include "lsst/sphgeom/Angle.h"
 #include "lsst/sphgeom/Vector3d.h"
 


### PR DESCRIPTION
As of 11.0, libstdc++ fixed places where standard library headers
were including other headers that they did not need to depend on.
As a result, an implicit include of `<limits>` must now be made
explicit in more places.

Add an explicit include of `<limits>` to every file that uses
std::numeric_limits.

https://www.gnu.org/software/gcc/gcc-11/porting_to.html#header-dep-changes
has more discussion.