### PR TITLE
DM-23308: Add CMake support

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -1,0 +1,31 @@
+name: cmake
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  cmake:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install Python prereqs
+        run: pip install pybind11[global]
+
+      - name: CMake configure
+        run: cmake -B ${{github.workspace}}/build
+
+      - name: CMake build
+        run: cmake --build ${{github.workspace}}/build --parallel `nproc`
+
+      - name: CMake test
+        working-directory: ${{github.workspace}}/build
+        run: ctest  --parallel `nproc`

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -18,14 +18,32 @@ jobs:
           python-version: 3.8
 
       - name: Install Python prereqs
-        run: pip install pybind11[global]
+        run: |
+          pip install \
+            numpy \
+            pybind11[global] \
+            pytest \
+            pytest-flake8 \
+            pyyaml
 
       - name: CMake configure
-        run: cmake -B ${{github.workspace}}/build
+        run: |
+          cmake \
+            -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/build/install \
+            -B ${{github.workspace}}/build
 
       - name: CMake build
         run: cmake --build ${{github.workspace}}/build --parallel `nproc`
 
       - name: CMake test
         working-directory: ${{github.workspace}}/build
-        run: ctest  --parallel `nproc`
+        run: ctest
+
+      - name: CMake install
+        run: cmake --build ${{github.workspace}}/build --target install
+
+      - name: Python tests
+        env:
+          PYTHONPATH: ${{github.workspace}}/build/install/python
+          LD_LIBRARY_PATH: ${{github.workspace}}/build/install/lib
+        run: pytest -r a -v

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.1)
+project(sphgeom)
+
+add_subdirectory(python/lsst/sphgeom)
+add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(sphgeom)
 
+enable_testing()
+
 add_subdirectory(python/lsst/sphgeom)
 add_subdirectory(src)
+add_subdirectory(tests)

--- a/include/lsst/sphgeom/NormalizedAngle.h
+++ b/include/lsst/sphgeom/NormalizedAngle.h
@@ -70,10 +70,10 @@ public:
                                   NormalizedAngle const & b);
 
     /// This constructor creates a NormalizedAngle with a value of zero.
-    NormalizedAngle() {}
+    NormalizedAngle() = default;
 
     /// This constructor creates a copy of a.
-    NormalizedAngle(NormalizedAngle const & a) : _a(a._a) {}
+    NormalizedAngle(NormalizedAngle const & a) = default;
 
     /// This constructor creates a normalized copy of a.
     explicit NormalizedAngle(Angle const & a) {

--- a/include/lsst/sphgeom/UnitVector3d.h
+++ b/include/lsst/sphgeom/UnitVector3d.h
@@ -105,7 +105,7 @@ public:
     /// The default constructor creates a unit vector equal to (1, 0, 0).
     UnitVector3d() : _v(1.0, 0.0, 0.0) {}
 
-    UnitVector3d(UnitVector3d const & v) : _v(v._v) {}
+    UnitVector3d(UnitVector3d const &v) = default;
 
     ///@{
     /// This constructor creates a unit vector with the given direction.

--- a/python/lsst/sphgeom/CMakeLists.txt
+++ b/python/lsst/sphgeom/CMakeLists.txt
@@ -1,0 +1,50 @@
+find_package(pybind11 REQUIRED)
+
+pybind11_add_module(_sphgeom
+    _angle.cc
+    _angleInterval.cc
+    _box3d.cc
+    _box.cc
+    _chunker.cc
+    _circle.cc
+    _convexPolygon.cc
+    _curve.cc
+    _ellipse.cc
+    _htmPixelization.cc
+    _interval1d.cc
+    _lonLat.cc
+    _matrix3d.cc
+    _mq3cPixelization.cc
+    _normalizedAngle.cc
+    _normalizedAngleInterval.cc
+    _orientation.cc
+    _pixelization.cc
+    _q3cPixelization.cc
+    _rangeSet.cc
+    _region.cc
+    _relationship.cc
+    _sphgeom.cc
+    _unitVector3d.cc
+    _utils.cc
+    _vector3d.cc
+)
+
+target_link_libraries(_sphgeom PUBLIC sphgeom)
+
+install(TARGETS _sphgeom DESTINATION ${CMAKE_INSTALL_PREFIX}/python/lsst/sphgeom)
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/python/lsst/sphgeom
+    FILES_MATCHING PATTERN "*.py"
+)
+
+add_custom_target(sphgeom_version ALL
+    ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/version.cmake
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/version.py
+)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/version.py
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/python/lsst/sphgeom
+)

--- a/python/lsst/sphgeom/version.cmake
+++ b/python/lsst/sphgeom/version.cmake
@@ -1,0 +1,27 @@
+execute_process(
+    COMMAND git describe --all --always --dirty
+    OUTPUT_VARIABLE GIT_REV
+    ERROR_QUIET
+)
+
+if("${GIT_REV}" STREQUAL "")
+    set(GIT_REV "unknown")
+endif()
+
+string(STRIP ${GIT_REV} GIT_REV)
+string(REGEX REPLACE "^(heads|tags)/" "" GIT_REV "${GIT_REV}")
+string(REPLACE "/" "_" GIT_REV "${GIT_REV}")
+
+set(VERSION_PY "__version__ = '${GIT_REV}'
+__all__ = ('__version__',)
+")
+
+if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/version.py)
+    file(READ ${CMAKE_CURRENT_BINARY_DIR}/version.py VERSION_PY_)
+else()
+    set(VERSION_PY_ "")
+endif()
+
+if(NOT "${VERSION_PY}" STREQUAL "${VERSION_PY_}")
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/version.py "${VERSION_PY}")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(sphgeom SHARED)
 
 target_compile_features(sphgeom PRIVATE 
-    cxx_std_14
+    cxx_std_17
 )
 
 set_target_properties(sphgeom PROPERTIES 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,45 @@
+add_library(sphgeom SHARED)
+
+target_compile_features(sphgeom PRIVATE 
+    cxx_std_14
+)
+
+set_target_properties(sphgeom PROPERTIES 
+    CXX_EXTENSIONS OFF
+    POSITION_INDEPENDENT_CODE ON
+)
+
+target_include_directories(sphgeom PUBLIC
+    ${PROJECT_SOURCE_DIR}/include
+)
+
+target_sources(sphgeom PRIVATE
+    Angle.cc
+    AngleInterval.cc
+    BigInteger.cc
+    Box3d.cc
+    Box.cc
+    Chunker.cc
+    Circle.cc
+    ConvexPolygon.cc
+    ConvexPolygonImpl.h
+    Ellipse.cc
+    HtmPixelization.cc
+    Interval1d.cc
+    LonLat.cc
+    Matrix3d.cc
+    Mq3cPixelization.cc
+    NormalizedAngle.cc
+    NormalizedAngleInterval.cc
+    orientation.cc
+    PixelFinder.h
+    Q3cPixelization.cc
+    Q3cPixelizationImpl.h
+    RangeSet.cc
+    Region.cc
+    UnitVector3d.cc
+    utils.cc
+    Vector3d.cc
+)
+
+install(TARGETS sphgeom)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,31 @@
+FUNCTION(sphgeom_tests)
+    FOREACH(TEST IN ITEMS ${ARGV})
+        add_executable(${TEST} ${TEST}.cc)
+        target_link_libraries(${TEST} PUBLIC sphgeom)
+        add_test(NAME ${TEST} COMMAND ${TEST})
+    ENDFOREACH()
+ENDFUNCTION()
+
+sphgeom_tests(
+    testAngle
+    testAngleInterval
+    testBigInteger
+    testBox
+    testChunker
+    testCircle
+    testConvexPolygon
+    testCurve
+    testEllipse
+    testHtmPixelization
+    testInterval1d
+    testLonLat
+    testMatrix3d
+    testMq3cPixelization
+    testNormalizedAngle
+    testNormalizedAngleInterval
+    testOrientation
+    testQ3cPixelization
+    testRangeSet
+    testUnitVector3d
+    testVector3d
+)


### PR DESCRIPTION
Adds ability to build package with CMake in addition to eupspkg (allows to be included as submodule in other CMake projects, e.g. Qserv.)