### PR TITLE
DM-12659: Clean up Doxygen tagfile imports

### DIFF
--- a/ups/sphgeom.cfg
+++ b/ups/sphgeom.cfg
@@ -4,7 +4,7 @@ import lsst.sconsUtils
 
 dependencies = {
     "required": [],
-    "buildRequired": ["sconsUtils", "pybind11"],
+    "buildRequired": ["pybind11"],
 }
 
 config = lsst.sconsUtils.Configuration(


### PR DESCRIPTION
This PR stops C++ imports of `sconsUtils`, fixing a missing tagfile error; `sconsUtils` is pure Python and does not produce Doxygen tag files.