### PR TITLE
Backport DM-32605 and DM-32254

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Build and install
         run: |

--- a/python/lsst/sphgeom/__init__.py
+++ b/python/lsst/sphgeom/__init__.py
@@ -28,5 +28,6 @@ from ._sphgeom import Pixelization
 from .version import *
 from ._yaml import *
 from .pixelization_abc import *
+from ._healpixPixelization import *
 
 PixelizationABC.register(Pixelization)

--- a/python/lsst/sphgeom/__init__.py
+++ b/python/lsst/sphgeom/__init__.py
@@ -24,5 +24,9 @@
 """
 
 from ._sphgeom import *
+from ._sphgeom import Pixelization
 from .version import *
 from ._yaml import *
+from .pixelization_abc import *
+
+PixelizationABC.register(Pixelization)

--- a/python/lsst/sphgeom/_healpixPixelization.py
+++ b/python/lsst/sphgeom/_healpixPixelization.py
@@ -1,0 +1,168 @@
+# This file is part of sphgeom.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+__all__ = ["HealpixPixelization"]
+
+import numpy as np
+import healpy as hp
+
+from ._sphgeom import RangeSet, Region, UnitVector3d
+from ._sphgeom import Box, Circle, ConvexPolygon, Ellipse
+from .pixelization_abc import PixelizationABC
+
+
+class HealpixPixelization(PixelizationABC):
+    """HEALPix pixelization class.
+
+    Parameters
+    ----------
+    level : `int`
+        Pixelization level.  HEALPix nside = 2**level
+    """
+    MAX_LEVEL = 17
+
+    def __init__(self, level: int):
+
+        if level < 0:
+            raise ValueError("HealPix level must be >= 0.")
+
+        self._level = level
+        self._nside = 2**level
+
+        self._npix = hp.nside2npix(self._nside)
+
+        # Values used to do pixel/region intersections
+        self._bit_shift = 8
+        self._nside_highres = self._nside*(2**(self._bit_shift//2))
+
+    @property
+    def nside(self):
+        return self._nside
+
+    def getLevel(self):
+        return self._level
+
+    level = property(getLevel)
+
+    def universe(self) -> RangeSet:
+        return RangeSet(0, self._npix)
+
+    def pixel(self, i) -> Region:
+        # This is arbitrarily returning 4 points on a side
+        # to approximate the pixel shape.
+        varr = hp.boundaries(self._nside, i, step=4, nest=True).T
+        return ConvexPolygon([UnitVector3d(*c) for c in varr])
+
+    def index(self, v: UnitVector3d) -> int:
+        return hp.vec2pix(self._nside, v.x(), v.y(), v.z(), nest=True)
+
+    def toString(self, i: int) -> str:
+        return str(i)
+
+    def envelope(self, region: Region, maxRanges: int = 0):
+        if maxRanges > 0:
+            # If this is important, the rangeset can be consolidated.
+            raise NotImplementedError("HealpixPixelization: maxRanges not implemented")
+        pixels_highres = self._interior_pixels_from_region(self._nside_highres, region)
+
+        # Dilate the high resolution pixels by one to ensure that the full
+        # region is completely covered at high resolution.
+        neighbors = hp.get_all_neighbours(self._nside_highres,
+                                          pixels_highres,
+                                          nest=True)
+        # Shift back to the original resolution and uniquify
+        pixels = np.unique(np.right_shift(neighbors, self._bit_shift))
+
+        return RangeSet(pixels)
+
+    def interior(self, region: Region, maxRanges: int = 0):
+        if maxRanges > 0:
+            # If this is important, the rangeset can be consolidated.
+            raise NotImplementedError("HealpixPixelization: maxRanges not implemented")
+        pixels = self._interior_pixels_from_region(self._nside, region)
+
+        # Check that the corners of the pixels are entirely enclosed in
+        # the region
+
+        # Returns array [npixels, 3, ncorners], where ncorners is 4, and
+        # the center index points to x, y, z.
+        corners = hp.boundaries(self._nside, pixels, step=1, nest=True)
+
+        corners_int = region.contains(corners[:, 0, :].ravel(),
+                                      corners[:, 1, :].ravel(),
+                                      corners[:, 2, :].ravel()).reshape((len(pixels), 4))
+        interior = (np.sum(corners_int, axis=1) == 4)
+        pixels = pixels[interior]
+
+        return RangeSet(pixels)
+
+    def _interior_pixels_from_region(self, nside: int, region: Region):
+        """Get interior pixels from a region.
+
+        Parameters
+        ----------
+        nside : `int`
+            Healpix nside to retrieve interior pixels.
+        region : `lsst.sphgeom.Region`
+            Sphgeom region to find interior pixels.
+
+        Returns
+        -------
+        pixels : `np.ndarray`
+            Array of pixels at resolution nside, nest ordering.
+        """
+        _circle = None
+        _poly = None
+        if isinstance(region, (Box, Ellipse)):
+            _circle = region.getBoundingCircle()
+        elif isinstance(region, Circle):
+            _circle = region
+        elif isinstance(region, ConvexPolygon):
+            _poly = region
+        else:
+            raise ValueError("Invalid region.")
+
+        # Find all pixels at an arbitrarily higher resolution
+        if _circle is not None:
+            center = _circle.getCenter()
+            vec = np.array([center.x(), center.y(), center.z()]).T
+            pixels = hp.query_disc(nside,
+                                   vec,
+                                   _circle.getOpeningAngle().asRadians(),
+                                   inclusive=False,
+                                   nest=True)
+        else:
+            vertices = np.array([[v.x(), v.y(), v.z()] for v in _poly.getVertices()])
+            pixels = hp.query_polygon(nside,
+                                      vertices,
+                                      inclusive=False,
+                                      nest=True)
+
+        return pixels
+
+    def __eq__(self, other):
+        if isinstance(other, HealpixPixelization):
+            return (self._level == other._level)
+
+    def __repr__(self):
+        return f"HealpixPixelization({self._level})"
+
+    def __reduce__(self):
+        return (self.__class__, (self._level, ))

--- a/python/lsst/sphgeom/_yaml.py
+++ b/python/lsst/sphgeom/_yaml.py
@@ -42,6 +42,8 @@ from ._sphgeom import (
     Q3cPixelization,
 )
 
+from ._healpixPixelization import HealpixPixelization
+
 
 if yaml:
     try:
@@ -107,6 +109,7 @@ def pixel_constructor(loader, node):
     pixelMap = {"lsst.sphgeom.Q3cPixelization": Q3cPixelization,
                 "lsst.sphgeom.Mq3cPixelization": Mq3cPixelization,
                 "lsst.sphgeom.HtmPixelization": HtmPixelization,
+                "lsst.sphgeom.HealpixPixelization": HealpixPixelization,
                 }
 
     if className not in pixelMap:
@@ -118,7 +121,7 @@ def pixel_constructor(loader, node):
 
 # All the pixelization schemes use the same approach with getLevel
 if yaml:
-    for pixelSchemeCls in (HtmPixelization, Q3cPixelization, Mq3cPixelization):
+    for pixelSchemeCls in (HtmPixelization, Q3cPixelization, Mq3cPixelization, HealpixPixelization):
         yaml.add_representer(pixelSchemeCls, pixel_representer)
         for loader in YamlLoaders:
             yaml.add_constructor(f"lsst.sphgeom.{pixelSchemeCls.__name__}", pixel_constructor, Loader=loader)

--- a/python/lsst/sphgeom/pixelization_abc.py
+++ b/python/lsst/sphgeom/pixelization_abc.py
@@ -1,0 +1,141 @@
+# This file is part of sphgeom.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+__all__ = ["PixelizationABC"]
+
+import abc
+from ._sphgeom import RangeSet, Region, UnitVector3d
+
+
+class PixelizationABC(abc.ABC):
+    """Pixelization ABC class that should be a base for
+    Python implementations of pixelization.
+    """
+
+    @abc.abstractmethod
+    def universe(self) -> RangeSet:
+        """Return the set of all pixel indexes for this pixelization.
+
+        Returns
+        -------
+        `lsst.sphgeom.RangeSet`
+        """
+        pass
+
+    @abc.abstractmethod
+    def pixel(self, i) -> Region:
+        """Return the spherical region corresponding to the pixel with index i.
+
+        This region will contain all unit vectors v with `index(v) == i`. But
+        it may also contain points with index not equal to i. To see why,
+        consider a point that lies on the edge of a polygonal pixel - it is
+        inside the polygons for both pixels sharing the edge, but must be
+        assigned to exactly one pixel by the pixelization.
+
+        Parameters
+        ----------
+        i: `int`
+            Pixel index.
+
+        Returns
+        -------
+        `lsst.sphgeom.Region`
+            The spherical region corresponding to the pixel with index i
+
+        Raises
+        ------
+        `InvalidArgumentExceptiont`
+            If i is not a valid pixel index.
+        """
+        pass
+
+    @abc.abstractmethod
+    def index(self, v: UnitVector3d) -> int:
+        """ Compute the index of the pixel.
+
+        Parameters
+        ----------
+        v: `lsst.sphgeom.UnitVector3d)`
+
+        Returns
+        -------
+        `int`
+            The index of the pixel.
+        """
+        pass
+
+    @abc.abstractmethod
+    def toString(self, i: int) -> str:
+        """Convert the given pixel index to a human-readable string.
+
+        Parameters
+        ----------
+        i: `int`
+
+        Returns
+        -------
+        `str`
+        """
+        pass
+
+    @abc.abstractmethod
+    def envelope(self, region: Region, maxRanges: int = 0):
+        """Return the indexes of the pixels intersecting the spherical region.
+
+        The `maxRanges` parameter can be used to limit both these costs -
+        setting it to a non-zero value sets a cap on the number of ranges
+        returned by this method. To meet this constraint, implementations are
+        allowed to return pixels that do not intersect r along with those that
+        do. This allows two ranges [a, b) and [c, d), a < b < c < d, to be
+        merged into one range [a, d) (by adding in the pixels [b, c)). Since
+        simplification proceeds by adding pixels, the return value will always
+        be a superset of the intersecting pixels.
+
+        Parameters
+        ----------
+        region: `lsst.sphgeom.Region`
+        maxRanges: `int`
+
+        Returns
+        -------
+        `lsst.sphgeom.RangeSet`
+        """
+        pass
+
+    @abc.abstractmethod
+    def interior(self, region: Region, maxRanges: int = 0):
+        """Return the indexes of the pixels within the spherical region.
+
+        The `maxRanges` argument is analogous to the identically named
+        envelope() argument. The only difference is that implementations must
+        remove interior pixels to keep the number of ranges at or below the
+        maximum. The return value is therefore always a subset of the interior
+        pixels.
+
+        Parameters
+        ----------
+        region: `lsst.sphgeom.Region`
+        maxRanges: `int`
+
+        Returns
+        -------
+        `lsst.sphgeom.RangeSet`
+        """
+        pass

--- a/python/lsst/sphgeom/pixelization_abc.py
+++ b/python/lsst/sphgeom/pixelization_abc.py
@@ -35,34 +35,34 @@ class PixelizationABC(abc.ABC):
 
         Returns
         -------
-        `lsst.sphgeom.RangeSet`
+        rangeSet : `lsst.sphgeom.RangeSet`
         """
         pass
 
     @abc.abstractmethod
     def pixel(self, i) -> Region:
-        """Return the spherical region corresponding to the pixel with index i.
+        """Return the spherical region corresponding to the pixel index ``i``.
 
-        This region will contain all unit vectors v with `index(v) == i`. But
-        it may also contain points with index not equal to i. To see why,
-        consider a point that lies on the edge of a polygonal pixel - it is
-        inside the polygons for both pixels sharing the edge, but must be
-        assigned to exactly one pixel by the pixelization.
+        This region will contain all unit vectors v with ``index(v) == i``.
+        But it may also contain points with index not equal to ``i``.
+        To see why, consider a point that lies on the edge of a polygonal
+        pixel - it is inside the polygons for both pixels sharing the edge,
+        but must be assigned to exactly one pixel by the pixelization.
 
         Parameters
         ----------
-        i: `int`
+        i : `int`
             Pixel index.
 
         Returns
         -------
-        `lsst.sphgeom.Region`
-            The spherical region corresponding to the pixel with index i
+        region : `lsst.sphgeom.Region`
+            The spherical region corresponding to the pixel with index ``i``
 
         Raises
         ------
-        `InvalidArgumentExceptiont`
-            If i is not a valid pixel index.
+        `InvalidArgumentException`
+            Raised if ``i`` is not a valid pixel index.
         """
         pass
 
@@ -72,11 +72,11 @@ class PixelizationABC(abc.ABC):
 
         Parameters
         ----------
-        v: `lsst.sphgeom.UnitVector3d)`
+        v : `lsst.sphgeom.UnitVector3d`
 
         Returns
         -------
-        `int`
+        i : `int`
             The index of the pixel.
         """
         pass
@@ -87,11 +87,11 @@ class PixelizationABC(abc.ABC):
 
         Parameters
         ----------
-        i: `int`
+        i : `int`
 
         Returns
         -------
-        `str`
+        s : `str`
         """
         pass
 
@@ -99,23 +99,24 @@ class PixelizationABC(abc.ABC):
     def envelope(self, region: Region, maxRanges: int = 0):
         """Return the indexes of the pixels intersecting the spherical region.
 
-        The `maxRanges` parameter can be used to limit both these costs -
+        The ``maxRanges`` parameter can be used to limit both these costs -
         setting it to a non-zero value sets a cap on the number of ranges
         returned by this method. To meet this constraint, implementations are
-        allowed to return pixels that do not intersect r along with those that
-        do. This allows two ranges [a, b) and [c, d), a < b < c < d, to be
+        allowed to return pixels that do not intersect the region along with
+        those, that do.
+        This allows two ranges [a, b) and [c, d), a < b < c < d, to be
         merged into one range [a, d) (by adding in the pixels [b, c)). Since
         simplification proceeds by adding pixels, the return value will always
         be a superset of the intersecting pixels.
 
         Parameters
         ----------
-        region: `lsst.sphgeom.Region`
-        maxRanges: `int`
+        region : `lsst.sphgeom.Region`
+        maxRanges : `int`
 
         Returns
         -------
-        `lsst.sphgeom.RangeSet`
+        rangeSet : `lsst.sphgeom.RangeSet`
         """
         pass
 
@@ -123,7 +124,7 @@ class PixelizationABC(abc.ABC):
     def interior(self, region: Region, maxRanges: int = 0):
         """Return the indexes of the pixels within the spherical region.
 
-        The `maxRanges` argument is analogous to the identically named
+        The ``maxRanges`` argument is analogous to the identically named
         envelope() argument. The only difference is that implementations must
         remove interior pixels to keep the number of ranges at or below the
         maximum. The return value is therefore always a subset of the interior
@@ -131,11 +132,11 @@ class PixelizationABC(abc.ABC):
 
         Parameters
         ----------
-        region: `lsst.sphgeom.Region`
-        maxRanges: `int`
+        region : `lsst.sphgeom.Region`
+        maxRanges : `int`
 
         Returns
         -------
-        `lsst.sphgeom.RangeSet`
+        rangeSet : `lsst.sphgeom.RangeSet`
         """
         pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ package_dir=
 packages=find:
 install_requires =
   numpy >=1.18
+  healpy
 
 [options.extras_require]
 yaml = pyyaml>=5.1

--- a/tests/test_HealpixPixelization.py
+++ b/tests/test_HealpixPixelization.py
@@ -1,0 +1,202 @@
+#
+# LSST Data Management System
+# See COPYRIGHT file at the top of the source tree.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+import unittest
+import numpy as np
+import healpy as hp
+
+import pickle
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from lsst.sphgeom import (Angle, Circle, HealpixPixelization,
+                          UnitVector3d, ConvexPolygon, LonLat, Box)
+
+
+class HealpixPixelizationTestCase(unittest.TestCase):
+    def test_construction(self):
+        """Test construction of a HealpixPixelization."""
+        with self.assertRaises(ValueError):
+            HealpixPixelization(-1)
+        h1 = HealpixPixelization(5)
+        self.assertEqual(h1.level, 5)
+        self.assertEqual(h1.getLevel(), 5)
+        self.assertEqual(h1.nside, 32)
+        h2 = HealpixPixelization(6)
+        h3 = HealpixPixelization(h2.level)
+        self.assertNotEqual(h1, h2)
+        self.assertEqual(h2, h3)
+
+    def test_indexing(self):
+        """Test indexing of HealpixPixelization."""
+        h = HealpixPixelization(5)
+        vec = UnitVector3d(1, 1, 1)
+        lonlat = LonLat(vec)
+        pix = hp.ang2pix(h.nside,
+                         lonlat.getLon().asDegrees(),
+                         lonlat.getLat().asDegrees(),
+                         lonlat=True,
+                         nest=True)
+        self.assertEqual(h.index(UnitVector3d(1, 1, 1)), pix)
+
+    def test_pixel(self):
+        """Test pixel polygon of HealpixPixelization."""
+        h = HealpixPixelization(5)
+        pix_poly = h.pixel(10)
+        self.assertIsInstance(pix_poly, ConvexPolygon)
+
+    def test_envelope(self):
+        """Test envelope method of HealpixPixelization."""
+        # Make the hardest intersection: a region that _just_
+        # touches a healpix pixel.
+        h = HealpixPixelization(5)
+        pix = hp.ang2pix(h.nside, 50.0, 20.0, lonlat=True, nest=True)
+
+        corners = hp.boundaries(h.nside, pix, step=1, nest=True)
+        corners_ra, corners_dec = hp.vec2ang(corners.T, lonlat=True)
+
+        # Take the southernmost corner...
+        smost = np.argmin(corners_dec)
+
+        # Choose challenging comparison box corners:
+        ra_range = np.array([corners_ra[smost] - 0.5,
+                             corners_ra[smost] + 0.5])
+        dec_range = np.array([corners_dec[smost] - 0.5,
+                              corners_dec[smost] + 1e-8])
+
+        # Test the box region
+        box = Box(point1=LonLat.fromDegrees(ra_range[0], dec_range[0]),
+                  point2=LonLat.fromDegrees(ra_range[1], dec_range[1]))
+        # These pixels have been checked to completely overlap the region
+        self._check_envelope(h, box, [98, 99, 104, 105])
+
+        # Try a polygon region:
+        poly = ConvexPolygon([UnitVector3d(LonLat.fromDegrees(ra_range[0], dec_range[0])),
+                              UnitVector3d(LonLat.fromDegrees(ra_range[1], dec_range[0])),
+                              UnitVector3d(LonLat.fromDegrees(ra_range[1], dec_range[1])),
+                              UnitVector3d(LonLat.fromDegrees(ra_range[0], dec_range[1])),
+                              UnitVector3d(LonLat.fromDegrees(ra_range[0], dec_range[0]))])
+        self._check_envelope(h, poly, [98, 99, 104, 105])
+
+        # Try a circle region
+        circle = Circle(center=UnitVector3d(LonLat.fromDegrees((ra_range[0] + ra_range[1])/2.,
+                                                               (dec_range[0] + dec_range[1])/2.)),
+                        angle=Angle.fromDegrees((dec_range[1] - dec_range[0])/2.))
+        self._check_envelope(h, circle, [98, 99, 104, 105])
+
+    def _check_envelope(self, pixelization, region, check_pixels):
+        """Check the envelope from a region.
+
+        Parameters
+        ----------
+        pixelization : `lsst.sphgeom.HealpixPixelization`
+        region : `lsst.sphgeom.Region`
+        check_pixels : `list` [`int`]
+        """
+        pixel_range = pixelization.envelope(region)
+
+        pixels = []
+        for r in pixel_range.ranges():
+            pixels.extend(range(r[0], r[1]))
+
+        self.assertEqual(pixels, check_pixels)
+
+    def test_interior(self):
+        """Test interior method of HealpixPixelization."""
+
+        h = HealpixPixelization(5)
+        pix = hp.ang2pix(h.nside, 50.0, 20.0, lonlat=True, nest=True)
+
+        corners = hp.boundaries(h.nside, pix, step=1, nest=True)
+        corners_ra, corners_dec = hp.vec2ang(corners.T, lonlat=True)
+
+        ra_range = np.array([corners_ra.min() - 1.0, corners_ra.max() + 1.0])
+        dec_range = np.array([corners_dec.min() - 1.0, corners_dec.max() + 1.0])
+
+        # Test the box region
+        box = Box(point1=LonLat.fromDegrees(ra_range[0], dec_range[0]),
+                  point2=LonLat.fromDegrees(ra_range[1], dec_range[1]))
+        # These pixels have been checked to completely overlap the region
+        self._check_interior(h, box, [pix])
+
+        # Try a polygon region:
+        poly = ConvexPolygon([UnitVector3d(LonLat.fromDegrees(ra_range[0], dec_range[0])),
+                              UnitVector3d(LonLat.fromDegrees(ra_range[1], dec_range[0])),
+                              UnitVector3d(LonLat.fromDegrees(ra_range[1], dec_range[1])),
+                              UnitVector3d(LonLat.fromDegrees(ra_range[0], dec_range[1])),
+                              UnitVector3d(LonLat.fromDegrees(ra_range[0], dec_range[0]))])
+        self._check_interior(h, poly, [pix])
+
+        # Try a circle region
+        circle = Circle(center=UnitVector3d(LonLat.fromDegrees((ra_range[0] + ra_range[1])/2.,
+                                                               (dec_range[0] + dec_range[1])/2.)),
+                        angle=Angle.fromDegrees(2.5))
+        self._check_interior(h, circle, [pix])
+
+    def _check_interior(self, pixelization, region, check_pixels):
+        """Check the interior from a region.
+
+        Parameters
+        ----------
+        pixelization : `lsst.sphgeom.HealpixPixelization`
+        region : `lsst.sphgeom.Region`
+        check_pixels : `list` [`int`]
+        """
+        pixel_range = pixelization.interior(region)
+
+        pixels = []
+        for r in pixel_range.ranges():
+            pixels.extend(range(r[0], r[1]))
+
+        self.assertEqual(pixels, check_pixels)
+
+    def test_index_to_string(self):
+        """Test converting index to string of HealpixPixelization."""
+        h = HealpixPixelization(5)
+        self.assertEqual(h.toString(0), str(0))
+        self.assertEqual(h.toString(100), str(100))
+
+    def test_string(self):
+        """Test string representation of HealpixPixelization."""
+        h = HealpixPixelization(5)
+        self.assertEqual(str(h), 'HealpixPixelization(5)')
+        self.assertEqual(str(h), repr(h))
+        self.assertEqual(
+            h, eval(repr(h), dict(HealpixPixelization=HealpixPixelization)))
+
+    def test_pickle(self):
+        """Test pickling of HealpixPixelization."""
+        a = HealpixPixelization(5)
+        b = pickle.loads(pickle.dumps(a))
+        self.assertEqual(a, b)
+
+    @unittest.skipIf(not yaml, "YAML module can not be imported")
+    def test_yaml(self):
+        """Test yaml representation of HealpixPixelization."""
+        a = HealpixPixelization(5)
+        b = yaml.safe_load(yaml.dump(a))
+        self.assertEqual(a, b)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Necessary for accessing Healpix-enabled butler registries with v23.