### PR TITLE
DM-35690: Require pip version less than 22

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build and install
         run: |
-          python -m pip install --upgrade pip setuptools
+          python -m pip install --upgrade "pip<22" setuptools
           python -m pip install .[yaml,test]
 
       - name: Run tests


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
