### PR TITLE
Fixed decodeU64 bug; added support for aarch64-conda-linux-gnu-cc

### DIFF
--- a/include/lsst/sphgeom/codec.h
+++ b/include/lsst/sphgeom/codec.h
@@ -114,7 +114,7 @@ inline std::uint64_t decodeU64(uint8_t const * buffer) {
         (static_cast<uint64_t>(buffer[5]) << 40) +
         (static_cast<uint64_t>(buffer[6]) << 48) +
         (static_cast<uint64_t>(buffer[7]) << 56);
-    return d;
+    return u;
 #endif
 }
 

--- a/include/lsst/sphgeom/codec.h
+++ b/include/lsst/sphgeom/codec.h
@@ -24,7 +24,10 @@
 #define LSST_SPHGEOM_CODEC_H_
 
 // Optimized path requires little endian arch and support for unaligned loads.
-#if defined(__x86_64__) or (defined(__aarch64__) and defined(__LITTLE_ENDIAN__))
+#if defined(__x86_64__) or          \
+    (defined(__aarch64__) and       \
+     (defined(__LITTLE_ENDIAN__) or \
+      (defined(__BYTE_ORDER__) and __BYTE_ORDER__ == 1234)))
 #define OPTIMIZED_LITTLE_ENDIAN
 #endif
 


### PR DESCRIPTION
- Fixed the typo in decodeU64, which results in compilation error when compiled with aarch64-conda-linux-gnu-cc
- Modified `OPTIMIZED_LITTLE_ENDIAN` to support aarch64-conda-linux-gnu-cc compiler.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
