### PR TITLE
DM-39897: Use macos-11 for PyPI wheel build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
   pypi_wheel_build:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macOS-10.15"]
+        os: ["ubuntu-latest", "macos-11"]
     runs-on: ${{ matrix.os }}
     needs: [build_and_test]
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
GitHub dropped macOS-10.15 long ago (probably in March when the PyPI uploads failed).

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
