### PR TITLE
Add conda installation info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ properly for the distribution.  The main purpose for now is to allow
 other packages to pip install from the GitHub URL in their CI systems
 where sphgeom is a dependency.
 
+Installing with conda
+---------------------
+
+This package is also available on the community [conda-forge repository](https://anaconda.org/conda-forge/lsst-sphgeom). To install it in a conda environment execute `conda install --channel=conda-forge lsst-sphgeom`.
+
 See Also
 --------
 


### PR DESCRIPTION
[LSDB](https://github.com/astronomy-commons/lsdb), the LINCC Frameworks tool for spatial analysis of extremely large astronomical databases, depends on the `lsst-sphgeom` package. In the process of making LSDB conda installable we were required to build a recipe for `lsst-sphgeom` (and as a consequence for `lsst-versions`) so they would become conda installable too. The [pull request](https://github.com/conda-forge/staged-recipes/pull/24930) against conda-forge staged-recipes passed all checks and it is out for review. We appreciate any additional feedback! 

On another note, would any of the `lsst-sphgeom` contributors be willing to be added as a maintainer of the recipe?
