### PR TITLE
Turn off 3.8 and 3.9 in wheel build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["38", "39", "310", "311", "312", "313"]
+        python-version: ["310", "311", "312", "313"]
     runs-on: ${{ matrix.os }}
     needs: [build_and_test]
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
