### PR TITLE
DM-50218: Fixed an error when computing envelope for point region

### DIFF
--- a/python/lsst/sphgeom/_healpixPixelization.py
+++ b/python/lsst/sphgeom/_healpixPixelization.py
@@ -130,13 +130,24 @@ class HealpixPixelization(PixelizationABC):
         """
         if isinstance(region, Circle):
             center = LonLat(region.getCenter())
-            pixels = hpg.query_circle(
-                nside,
-                center.getLon().asRadians(),
-                center.getLat().asRadians(),
-                region.getOpeningAngle().asRadians(),
-                degrees=False,
-            )
+            radius_rad = region.getOpeningAngle().asRadians()
+            if radius_rad > 0:
+                pixels = hpg.query_circle(
+                    nside,
+                    center.getLon().asRadians(),
+                    center.getLat().asRadians(),
+                    radius_rad,
+                    degrees=False,
+                )
+            elif radius_rad == 0:
+                pixels = hpg.angle_to_pixel(
+                    nside,
+                    center.getLon().asRadians(),
+                    center.getLat().asRadians(),
+                    degrees=False,
+                )
+            else:
+                raise ValueError("Invalid circle radius.")
         elif isinstance(region, ConvexPolygon):
             vertices = np.array([[v.x(), v.y(), v.z()] for v in region.getVertices()])
             pixels = hpg.query_polygon_vec(nside, vertices)

--- a/tests/test_HealpixPixelization.py
+++ b/tests/test_HealpixPixelization.py
@@ -114,6 +114,14 @@ class HealpixPixelizationTestCase(unittest.TestCase):
         )
         self._check_envelope(h, circle, [98, 99, 104, 105])
 
+        # Try a circle region with zero-radius (representing a point)
+        pt_circle = Circle(
+            center=UnitVector3d(
+                LonLat.fromDegrees((ra_range[0] + ra_range[1]) / 2.0, (dec_range[0] + dec_range[1]) / 2.0)
+            ),
+        )
+        self._check_envelope(h, pt_circle, [98])
+
     def test_envelope_missing_neighbors(self):
         """Test envelope, with a pixel with missing neighbors.
 


### PR DESCRIPTION
This PR fixes `ValueError: Radius must be positive` for a case when Circle region with zero-radius is used to represent a point.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
