### PR TITLE
DM-51974: Update to `cmake` 3.12 or later

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 project(sphgeom)
 
 enable_testing()

--- a/python/lsst/sphgeom/CMakeLists.txt
+++ b/python/lsst/sphgeom/CMakeLists.txt
@@ -1,3 +1,4 @@
+find_package(Python COMPONENTS Development Interpreter)
 find_package(pybind11 REQUIRED)
 
 pybind11_add_module(_sphgeom


### PR DESCRIPTION
Newer installations are starting to whinge about soon-to-be-deprecated `cmake` < 3.10.  This upgrades minimal version from 3.1 to 3.10, and also updates to modern find python usage for pybind11.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
