### PR TITLE
DM-54630: Add GIL-free envelope_many function

### DIFF
--- a/python/lsst/sphgeom/_pixelization.cc
+++ b/python/lsst/sphgeom/_pixelization.cc
@@ -26,11 +26,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <vector>
+
 #include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
 
 #include "lsst/sphgeom/python.h"
 
 #include "lsst/sphgeom/Pixelization.h"
+#include "lsst/sphgeom/RangeSet.h"
 #include "lsst/sphgeom/Region.h"
 #include "lsst/sphgeom/UnitVector3d.h"
 
@@ -47,6 +51,19 @@ void defineClass(py::classh<Pixelization> &cls) {
     cls.def("index", &Pixelization::index, "i"_a);
     cls.def("toString", &Pixelization::toString, "i"_a);
     cls.def("envelope", &Pixelization::envelope, "region"_a, "maxRanges"_a = 0);
+    cls.def("envelope_many", [](const Pixelization& self, std::vector<const Region*> regions, int maxRanges = 0) {
+        py::gil_scoped_release release;
+        std::vector<RangeSet> output;
+        output.reserve(regions.size());
+
+        for (const Region* region : regions) {
+            output.push_back(self.envelope(*region, maxRanges));
+        }
+
+        return output;
+    },
+    "regions"_a,
+    "maxRanges"_a = 0);
     cls.def("interior", &Pixelization::interior, "region"_a, "maxRanges"_a = 0);
 }
 

--- a/python/lsst/sphgeom/pixelization_abc.py
+++ b/python/lsst/sphgeom/pixelization_abc.py
@@ -27,6 +27,7 @@
 __all__ = ["PixelizationABC"]
 
 import abc
+from collections.abc import Iterable
 
 from ._sphgeom import RangeSet, Region, UnitVector3d
 
@@ -126,6 +127,31 @@ class PixelizationABC(abc.ABC):
         rangeSet : `lsst.sphgeom.RangeSet`
         """
         pass
+
+    def envelope_many(self, regions: Iterable[Region], maxRanges: int = 0):
+        """Return the indexes of the pixels intersecting each given spherical
+        regions.
+
+        The ``maxRanges`` parameter can be used to limit both these costs -
+        setting it to a non-zero value sets a cap on the number of ranges
+        returned by this method. To meet this constraint, implementations are
+        allowed to return pixels that do not intersect the region along with
+        those, that do.
+        This allows two ranges [a, b) and [c, d), a < b < c < d, to be
+        merged into one range [a, d) (by adding in the pixels [b, c)). Since
+        simplification proceeds by adding pixels, the return value will always
+        be a superset of the intersecting pixels.
+
+        Parameters
+        ----------
+        regions : `~collections.abc.Iterable` [ `lsst.sphgeom.Region` ]
+        maxRanges : `int`
+
+        Returns
+        -------
+        rangeSets : `~collections.abc.Iterable` [ `lsst.sphgeom.RangeSet` ]
+        """
+        return [self.envelope(r, maxRanges) for r in regions]
 
     @abc.abstractmethod
     def interior(self, region: Region, maxRanges: int = 0):


### PR DESCRIPTION
Add a function for computing many calls to Pixelization::envelope(), with the Python GIL dropped.  This is intended to optimize the bulk load of Butler skypix overlap rows when inserting dimension records.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
